### PR TITLE
Add QA role and migrate runtime memory to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,14 +19,17 @@ TOP_TIER_PROPOSAL.md
 ENTERPRISE_PROPOSAL.md
 crew.local.yaml
 crew_memory.md
+crew_memory.db
 artifacts.jsonl
 branch_sessions.jsonl
 run_checkpoints.jsonl
 run_events.jsonl
 scoped_memory.jsonl
+scoped_memory.db
 metrics_history.jsonl
 .nexus_audit.jsonl
 .nexuscrew_state.db
+.nexuscrew_drill_memory.db
 .nexus_launch.json
 
 local_secrets.py

--- a/crew.example.yaml
+++ b/crew.example.yaml
@@ -58,6 +58,18 @@ agents:
       使用阿里 361 绩效体系（3.25/3.5/3.75）进行评分。
       督促消息需 @目标Agent 并抄送 @PM，重大问题 @Human。
 
+  # ── QA Agent（测试架构师 / 质量闸门）──────────────────────────────
+  # 走 Anthropic 线路，负责测试设计、质量闸门、发布前验证
+  - role: qa
+    name: nexus-qa-01
+    model: claude
+    anthropic_model: claude-opus-4-6
+    anthropic_model_light: claude-sonnet-4-6
+    system_prompt_extra: |
+      你负责质量闸门，不对“看起来能用”放行。
+      你要覆盖：功能测试、边界条件、回归风险、发布前 smoke test、回滚风险。
+      默认输出 Go / No-Go、覆盖项、风险项、下一步负责人。
+
 orchestrator:
   max_chain_hops: 10
   max_dev_retry: 5

--- a/nexuscrew/agents/qa.py
+++ b/nexuscrew/agents/qa.py
@@ -1,0 +1,104 @@
+"""QA Agent — elite test strategist and release-quality gate."""
+import asyncio
+
+from .base import AgentArtifacts, BaseAgent
+from ..backends.anthropic_backend import AnthropicBackend
+from ..backends.gemini_cli import GeminiCLIBackend
+from ..executor.shell import ShellExecutor
+
+QA_PROMPT = """\
+你是团队的首席 QA / Test Architect，代号 {name}。
+
+【你的定位】
+- 你不是“补一句测试通过”的人，你是发布质量闸门。
+- 你负责把模糊需求转成可验证的测试策略、风险矩阵和上线阻断条件。
+- 你优先发现回归风险、边界条件、兼容性问题、数据破坏风险、权限漏洞、幂等性问题、发布回滚风险。
+
+【你必须做的事】
+1. 明确测试范围：功能、边界、异常、回归、发布后验证。
+2. 对当前实现给出测试计划：先测什么，为什么测，阻断条件是什么。
+3. 如果需要验证，优先输出可执行的 ```bash ... ``` 命令去跑测试、检查日志、验证接口、核对文件或做 smoke test。
+4. 如果发现缺陷，明确给出：
+   - 严重级别
+   - 复现条件
+   - 期望结果
+   - 实际风险
+   - @具体负责人
+5. 如果允许继续推进，明确给出：
+   - 已覆盖项
+   - 未覆盖风险
+   - 是否 Go / No-Go
+
+【硬约束】
+- 默认不要改业务实现；你的主要职责是验证、挑错、补测试、给出质量结论。
+- 可以新增或修改测试、fixture、验证脚本，但不要悄悄改产品逻辑冒充“测试通过”。
+- 收到明确测试/验收/发布前检查任务后，禁止只回复“收到 / 在测 / 我看下 / 稍后给结论 / 测试中”。
+- 默认必须二选一：
+  1) 给出结构化测试结论或阻断项；
+  2) 直接执行验证命令并汇报结果。
+- Telegram 输出必须简洁：
+  - 测试结论
+  - 风险
+  - 变更/验证文件
+  - 下一步 @谁
+- 不要在群里贴大段代码或大段日志；原始执行细节留在 artifacts。
+- 需持久化重要风险、发布约束或回归结论时，在回复末尾加【MEMORY】标记。
+
+【优先关注】
+- 新增角色/配置是否真的生效
+- 路由 / 权限 / 审批 / 任务状态机是否回归
+- 群消息是否刷屏、静默、重复执行
+- 外部 GitHub / Slack / Telegram 网络抖动下是否降级而不是阻塞
+- 发布后是否可观测、可回滚、可定位
+
+【你理想的输出形态】
+- `结论: Go / No-Go`
+- `覆盖: ...`
+- `风险: ...`
+- `验证: ...`
+- `下一步: @...`
+"""
+
+
+class QAAgent(BaseAgent):
+    def __init__(
+        self,
+        name: str,
+        backend: AnthropicBackend | GeminiCLIBackend,
+        executor: ShellExecutor,
+        system_prompt_extra: str = "",
+        model_label: str = "claude",
+    ):
+        super().__init__(name, "qa", model_label, system_prompt_extra)
+        self.backend = backend
+        self.executor = executor
+
+    async def handle(
+        self,
+        message: str,
+        history: list[dict],
+        crew_memory: str,
+    ) -> tuple[str, AgentArtifacts]:
+        system = self._build_system(QA_PROMPT.format(name=self.name), crew_memory)
+        if self.model_label == "claude":
+            messages = []
+            for item in history[-10:]:
+                role = "assistant" if item.get("agent") == self.name else "user"
+                messages.append({"role": role, "content": item["content"][:800]})
+            messages.append({"role": "user", "content": message})
+            reply = await asyncio.to_thread(self.backend.complete, system, messages)
+        else:
+            history_text = "\n".join(
+                f"[{m.get('agent', '?')}]: {m['content'][:400]}"
+                for m in history[-10:]
+            )
+            prompt = f"{system}\n\n【近期对话】\n{history_text}\n\n【当前消息】\n{message}"
+            reply = await asyncio.to_thread(self.backend.complete, prompt)
+
+        shell_out = await self.executor.run_blocks(reply)
+        artifacts = AgentArtifacts(shell_output=shell_out)
+        if "【MEMORY】" in reply:
+            reply, artifacts.memory_note = reply.split("【MEMORY】", 1)
+            reply = reply.strip()
+            artifacts.memory_note = artifacts.memory_note.strip()
+        return reply, artifacts

--- a/nexuscrew/drill.py
+++ b/nexuscrew/drill.py
@@ -1,6 +1,7 @@
-"""Internal behavior drill runner for PM/Dev/Architect collaboration."""
+"""Internal behavior drill runner for full-lifecycle team simulation."""
 import asyncio
 import copy
+import random
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -19,6 +20,23 @@ from .router import Router
 from .slack.sync import NullSlackSync
 
 
+@dataclass(frozen=True)
+class DrillScenario:
+    id: str
+    title: str
+    summary: str
+    acceptance: list[str]
+    release_goal: str
+
+
+@dataclass
+class DrillStageResult:
+    name: str
+    owner: str
+    summary: str
+    success: bool
+
+
 @dataclass
 class DrillResult:
     scenario: str
@@ -27,10 +45,11 @@ class DrillResult:
     checks: list[str]
     report_text: str
     transcript: list[tuple[str | None, str]]
+    stage_results: list[DrillStageResult]
 
 
 class TeamDrillRunner:
-    """Run a lightweight collaboration drill in an isolated temp workspace."""
+    """Run a full-lifecycle collaboration drill in an isolated temp workspace."""
 
     IGNORE_NAMES = {
         ".venv",
@@ -48,13 +67,59 @@ class TeamDrillRunner:
         "branch_sessions.jsonl",
     }
 
+    SCENARIOS = [
+        DrillScenario(
+            id="status-board-hardening",
+            title="Harden stale-task status board behavior",
+            summary="Improve stale task handling so old dead tasks are auto-closed and status views stay clean.",
+            acceptance=[
+                "stale tasks with no active background run are auto-closed",
+                "Telegram receives summary-only updates",
+                "tests document the watchdog behavior",
+            ],
+            release_goal="prepare a release note describing the reduced Telegram noise and stronger anti-stall runtime",
+        ),
+        DrillScenario(
+            id="github-timeout-resilience",
+            title="Improve GitHub network resilience",
+            summary="Add safer handling for timeout / handshake failures in issue, comment, or PR network calls.",
+            acceptance=[
+                "network errors do not break the main task chain",
+                "summary of degraded behavior is preserved",
+                "tests cover the retry / fallback path",
+            ],
+            release_goal="prepare an operational note for GitHub degradation behavior",
+        ),
+        DrillScenario(
+            id="telegram-noise-reduction",
+            title="Reduce Telegram delivery noise",
+            summary="Ensure Dev work is summarized for Telegram while raw shell detail stays in artifacts.",
+            acceptance=[
+                "Telegram contains only concise summaries",
+                "artifacts still contain shell details",
+                "review stage verifies the public message style",
+            ],
+            release_goal="prepare a release note for summary-first Telegram delivery UX",
+        ),
+        DrillScenario(
+            id="task-follow-up-routing",
+            title="Refine follow-up routing behavior",
+            summary="Make only genuine progress follow-ups attach to older tasks while fresh requests create new tasks.",
+            acceptance=[
+                "status follow-ups attach correctly",
+                "new work creates a fresh task",
+                "tests cover both paths",
+            ],
+            release_goal="prepare release guidance for task continuity and follow-up handling",
+        ),
+    ]
+
     def __init__(self, config: CrewConfig, agent_factory):
         self.config = copy.deepcopy(config)
         self.agent_factory = agent_factory
 
     async def run(self, scenario: str = "team") -> DrillResult:
-        if scenario != "team":
-            raise ValueError(f"unsupported drill scenario: {scenario}")
+        selected = self._choose_scenario(scenario)
         workspace = self._prepare_workspace(self.config.project_dir)
         drill_config = self._build_drill_config(workspace)
         executor = ShellExecutor(
@@ -83,14 +148,38 @@ class TeamDrillRunner:
         )
 
         transcript: list[tuple[str | None, str]] = []
+        stage_results: list[DrillStageResult] = []
 
         async def capture_send(text: str, agent_name: str | None = None):
             transcript.append((agent_name, text))
 
-        prompt = self._build_team_prompt(drill_config)
-        await orchestrator.run_chain(prompt, 0, capture_send)
-        report = await self._build_report(orchestrator, drill_config, workspace, transcript)
+        task = await self._run_full_flow(orchestrator, drill_config, selected, capture_send, transcript, stage_results)
+        report = await self._build_report(
+            orchestrator,
+            drill_config,
+            workspace,
+            selected,
+            transcript,
+            stage_results,
+        )
+        if task is not None:
+            orchestrator.artifact_store.append(ArtifactRecord(
+                task_id=task.id,
+                run_id=orchestrator._task_run_ids.get((0, task.id), ""),
+                type="drill_report",
+                source="drill",
+                summary=f"score={report.score}",
+                content=report.report_text,
+            ))
         return report
+
+    def _choose_scenario(self, scenario: str) -> DrillScenario:
+        if scenario in ("team", "full", "random", ""):
+            return random.SystemRandom().choice(self.SCENARIOS)
+        for item in self.SCENARIOS:
+            if item.id == scenario:
+                return item
+        raise ValueError(f"unsupported drill scenario: {scenario}")
 
     def _prepare_workspace(self, source: Path) -> Path:
         target = Path(tempfile.mkdtemp(prefix="nexuscrew-drill-"))
@@ -107,30 +196,172 @@ class TeamDrillRunner:
         selected = []
         seen_roles = set()
         for spec in config.agents:
-            if spec.role in ("pm", "dev", "architect") and spec.role not in seen_roles:
+            if spec.role in ("pm", "dev", "architect", "qa", "hr") and spec.role not in seen_roles:
                 selected.append(copy.deepcopy(spec))
                 seen_roles.add(spec.role)
-        if {"pm", "dev", "architect"} - seen_roles:
-            missing = ", ".join(sorted({"pm", "dev", "architect"} - seen_roles))
-            raise ValueError(f"drill requires pm/dev/architect, missing: {missing}")
+        missing = {"pm", "dev", "architect"} - seen_roles
+        if missing:
+            missing_text = ", ".join(sorted(missing))
+            raise ValueError(f"drill requires pm/dev/architect, missing: {missing_text}")
         config.project_dir = workspace
         config.agents = selected
         config.hr.auto_eval_daily_limit = 0
         return config
 
-    def _build_team_prompt(self, config: CrewConfig) -> str:
-        pm = next(spec for spec in config.agents if spec.role == "pm")
-        dev = next(spec for spec in config.agents if spec.role == "dev")
-        architect = next(spec for spec in config.agents if spec.role == "architect")
+    async def _run_full_flow(
+        self,
+        orchestrator: Orchestrator,
+        config: CrewConfig,
+        scenario: DrillScenario,
+        send,
+        transcript: list[tuple[str | None, str]],
+        stage_results: list[DrillStageResult],
+    ):
+        pm = next(spec for spec in config.agents if spec.role == "pm").name
+        dev = next(spec for spec in config.agents if spec.role == "dev").name
+        architect = next(spec for spec in config.agents if spec.role == "architect").name
+        qa = next((spec.name for spec in config.agents if spec.role == "qa"), "")
+        hr = next((spec.name for spec in config.agents if spec.role == "hr"), "")
+
+        task = None
+        task = await self._run_stage(
+            orchestrator, send, task, stage_results,
+            stage_name="kickoff",
+            owner=pm,
+            prompt=self._prompt_kickoff(pm, dev, architect, scenario),
+        )
+        task = await self._run_stage(
+            orchestrator, send, task, stage_results,
+            stage_name="design",
+            owner=architect,
+            prompt=self._prompt_design(pm, dev, architect, scenario),
+        )
+        task = await self._run_stage(
+            orchestrator, send, task, stage_results,
+            stage_name="implementation",
+            owner=dev,
+            prompt=self._prompt_implementation(dev, architect, scenario),
+        )
+        task = await self._run_stage(
+            orchestrator, send, task, stage_results,
+            stage_name="review",
+            owner=architect,
+            prompt=self._prompt_review(dev, architect, scenario),
+        )
+        if qa:
+            task = await self._run_stage(
+                orchestrator, send, task, stage_results,
+                stage_name="quality_gate",
+                owner=qa,
+                prompt=self._prompt_quality_gate(qa, dev, architect, scenario),
+            )
+        task = await self._run_stage(
+            orchestrator, send, task, stage_results,
+            stage_name="acceptance",
+            owner=pm,
+            prompt=self._prompt_acceptance(pm, dev, architect, scenario),
+        )
+        task = await self._run_stage(
+            orchestrator, send, task, stage_results,
+            stage_name="release",
+            owner=pm,
+            prompt=self._prompt_release(pm, scenario),
+        )
+        if hr:
+            task = await self._run_stage(
+                orchestrator, send, task, stage_results,
+                stage_name="retrospective",
+                owner=hr,
+                prompt=self._prompt_retrospective(hr, scenario),
+            )
+        return task
+
+    async def _run_stage(
+        self,
+        orchestrator: Orchestrator,
+        send,
+        task,
+        stage_results: list[DrillStageResult],
+        stage_name: str,
+        owner: str,
+        prompt: str,
+    ):
+        initial_agent = orchestrator.registry.get_by_name(owner)
+        await orchestrator.run_chain(
+            f"@{owner} {prompt}",
+            0,
+            send,
+            initial_agent=initial_agent,
+            task=task,
+        )
+        task = task or orchestrator.task_tracker.latest_active(0)
+        # Read the last visible message from the stage owner for the stage summary.
+        summary = self._last_agent_message(orchestrator, owner) or f"{stage_name} completed"
+        success = self._stage_success(stage_name, summary)
+        stage_results.append(DrillStageResult(stage_name, owner, summary[:300], success))
+        return task
+
+    def _prompt_kickoff(self, pm: str, dev: str, architect: str, scenario: DrillScenario) -> str:
+        acceptance = "\n".join(f"- {item}" for item in scenario.acceptance)
         return (
-            "这是一次内部团队演练，不是正式需求。请在当前临时工作区完成一次最小协作闭环。\n\n"
-            f"要求：\n"
-            f"1. @{pm.name} 先拆成一个最小真实开发任务，并且只指派给 @{dev.name}。\n"
-            f"2. @{dev.name} 在临时工作区新增或更新 `DRILL_NOTE.md`，内容包含 `drill ok`。\n"
-            f"3. @{dev.name} 至少运行一个最小验证命令，完成后请求 @{architect.name} review。\n"
-            f"4. @{architect.name} 给出简短但具体的评审结论：LGTM 或具体问题。\n"
-            "5. Telegram 风格要求：只给摘要，不要贴大段代码，不要贴长日志。\n"
-            "6. 如果遇到阻塞，只说明一个真实阻塞点。\n"
+            f"[DRILL stage=kickoff scenario={scenario.id}] 这是一次内部全流程演练。\n"
+            f"任务标题：{scenario.title}\n"
+            f"任务摘要：{scenario.summary}\n"
+            f"验收标准：\n{acceptance}\n\n"
+            f"请由 @{pm} 输出一份真实工程 kickoff：需求澄清、风险、负责人分配、验收标准。"
+            f"只允许把开发任务派给 @{dev}，审查任务派给 @{architect}。"
+            "不要拉全员做状态汇报。"
+        )
+
+    def _prompt_design(self, pm: str, dev: str, architect: str, scenario: DrillScenario) -> str:
+        return (
+            f"[DRILL stage=design scenario={scenario.id}] 请做设计/风险评审。\n"
+            f"目标：{scenario.summary}\n"
+            f"要求：给 @{dev} 明确设计约束、review 关注点、发布前检查项。"
+            "必须给出具体结论，不要只说收到。"
+        )
+
+    def _prompt_implementation(self, dev: str, architect: str, scenario: DrillScenario) -> str:
+        return (
+            f"[DRILL stage=implementation scenario={scenario.id}] 请直接在当前临时工作区做一个最小真实实现。\n"
+            "要求：\n"
+            "- 落一个真实文件改动\n"
+            "- 跑至少一个验证命令\n"
+            "- Telegram 只给摘要，不要贴大段代码\n"
+            f"- 完成后请求 @{architect} review\n"
+            f"- 推荐创建/更新 `DRILL_NOTE.md` 并包含 `drill ok` 与 `{scenario.id}`\n"
+        )
+
+    def _prompt_review(self, dev: str, architect: str, scenario: DrillScenario) -> str:
+        return (
+            f"[DRILL stage=review scenario={scenario.id}] 请 review @{dev} 的实现结果。\n"
+            "要求：必须给出 `LGTM` 或具体问题，不要只确认收到。"
+        )
+
+    def _prompt_acceptance(self, pm: str, dev: str, architect: str, scenario: DrillScenario) -> str:
+        return (
+            f"[DRILL stage=acceptance scenario={scenario.id}] 请由 @{pm} 做验收。\n"
+            f"结合 @{dev} 的实现和 @{architect} 的审查，给出：是否验收通过、风险总结、是否允许进入发布准备。"
+        )
+
+    def _prompt_quality_gate(self, qa: str, dev: str, architect: str, scenario: DrillScenario) -> str:
+        return (
+            f"[DRILL stage=quality_gate scenario={scenario.id}] 请由 @{qa} 做测试与发布前质量闸门。\n"
+            f"结合 @{dev} 的实现和 @{architect} 的 review，给出：测试覆盖、阻断风险、Go/No-Go 结论。"
+            "如果需要验证，请直接执行最小必要的测试命令；不要只回复状态。"
+        )
+
+    def _prompt_release(self, pm: str, scenario: DrillScenario) -> str:
+        return (
+            f"[DRILL stage=release scenario={scenario.id}] 请由 @{pm} 输出一份发布准备说明。\n"
+            f"发布目标：{scenario.release_goal}\n"
+            "要求包含：发布摘要、风险、回滚点、发布后验证。"
+        )
+
+    def _prompt_retrospective(self, hr: str, scenario: DrillScenario) -> str:
+        return (
+            f"[DRILL stage=retrospective scenario={scenario.id}] 请由 @{hr} 输出团队复盘。\n"
+            "要求：逐个说明 PM / Dev / Architect 做了什么、哪里卡住、哪里做得好。保持简洁。"
         )
 
     async def _build_report(
@@ -138,85 +369,140 @@ class TeamDrillRunner:
         orchestrator: Orchestrator,
         config: CrewConfig,
         workspace: Path,
+        scenario: DrillScenario,
         transcript: list[tuple[str | None, str]],
+        stage_results: list[DrillStageResult],
     ) -> DrillResult:
-        pm = next(spec for spec in config.agents if spec.role == "pm").name
-        dev = next(spec for spec in config.agents if spec.role == "dev").name
-        architect = next(spec for spec in config.agents if spec.role == "architect").name
-        public_messages = [(agent_name or "system", text) for agent_name, text in transcript]
         changed_files = await orchestrator.executor.git_changed_files()
-
         checks: list[str] = []
         score = 100
 
-        pm_message = next((text for agent_name, text in public_messages if agent_name == pm), "")
-        dev_message = next((text for agent_name, text in public_messages if agent_name == dev), "")
-        architect_message = next((text for agent_name, text in public_messages if agent_name == architect), "")
+        stage_index = {result.name: result for result in stage_results}
 
-        pm_dev_mentions = pm_message.count(f"@{dev}")
-        if pm_dev_mentions >= 1 and "@nexus-dev-" not in pm_message.replace(f"@{dev}", ""):
-            checks.append("PM: pass — 单一指派明确。")
-        else:
-            score -= 20
-            checks.append("PM: fail — 指派不够清晰或一次点名过多开发者。")
-
-        if "```" in dev_message:
-            score -= 25
-            checks.append("Dev: fail — Telegram 仍出现代码块泄漏。")
-        else:
-            checks.append("Dev: pass — Telegram 仅输出摘要。")
-
-        if "Files:" in dev_message and "Validation:" in dev_message:
-            checks.append("Dev: pass — 摘要包含变更文件与验证结果。")
+        kickoff = stage_index.get("kickoff")
+        if kickoff and kickoff.success:
+            checks.append("Kickoff: pass — PM 完成了有效的需求拆解与任务分配。")
         else:
             score -= 15
-            checks.append("Dev: fail — 摘要缺少文件或验证信息。")
+            checks.append("Kickoff: fail — PM 的 kickoff 不够明确。")
 
-        if "LGTM" in architect_message or "打回" in architect_message or "需改进" in architect_message:
-            checks.append("Architect: pass — 评审结论具体。")
+        design = stage_index.get("design")
+        if design and design.success:
+            checks.append("Design: pass — Architect 提供了明确设计约束。")
+        else:
+            score -= 15
+            checks.append("Design: fail — Architect 未给出有效设计结论。")
+
+        implementation = stage_index.get("implementation")
+        if implementation and implementation.success:
+            checks.append("Implementation: pass — Dev 给出了有效执行结果。")
         else:
             score -= 20
-            checks.append("Architect: fail — 评审不够具体。")
+            checks.append("Implementation: fail — Dev 没有形成有效实现交付。")
 
-        drill_note = workspace / "DRILL_NOTE.md"
-        if drill_note.exists() and "drill ok" in drill_note.read_text(encoding="utf-8", errors="replace").lower():
-            checks.append("Workspace: pass — 临时工作区已产出演练文件。")
+        review = stage_index.get("review")
+        if review and review.success:
+            checks.append("Review: pass — Review 阶段有明确结果。")
         else:
-            score -= 20
-            checks.append("Workspace: fail — 演练文件未落地。")
+            score -= 15
+            checks.append("Review: fail — Review 阶段不完整。")
 
-        if changed_files:
-            checks.append("Git: pass — 临时工作区存在实际改动。")
+        quality_gate = stage_index.get("quality_gate")
+        if quality_gate:
+            if quality_gate.success:
+                checks.append("Quality Gate: pass — QA 给出了有效测试结论。")
+            else:
+                score -= 10
+                checks.append("Quality Gate: fail — QA 未给出有效质量闸门结论。")
+
+        acceptance = stage_index.get("acceptance")
+        if acceptance and acceptance.success:
+            checks.append("Acceptance: pass — PM 完成了验收判断。")
         else:
             score -= 10
-            checks.append("Git: fail — 未检测到工作区改动。")
+            checks.append("Acceptance: fail — 验收阶段不完整。")
 
+        release = stage_index.get("release")
+        if release and release.success:
+            checks.append("Release: pass — 发布准备说明已产出。")
+        else:
+            score -= 10
+            checks.append("Release: fail — 发布准备说明缺失。")
+
+        retrospective = stage_index.get("retrospective")
+        if retrospective:
+            checks.append("Retrospective: pass — 团队复盘已生成。")
+
+        if changed_files:
+            checks.append("Workspace: pass — 临时工作区存在实际文件改动。")
+        else:
+            score -= 15
+            checks.append("Workspace: fail — 临时工作区未检测到改动。")
+
+        drill_note = workspace / "DRILL_NOTE.md"
+        if drill_note.exists() and scenario.id in drill_note.read_text(encoding="utf-8", errors="replace"):
+            checks.append("Drill Artifact: pass — DRILL_NOTE.md 已写入场景痕迹。")
+        else:
+            score -= 10
+            checks.append("Drill Artifact: fail — 缺少 DRILL_NOTE.md 场景痕迹。")
+
+        contributions = self._build_contributions(stage_results)
         report_lines = [
             "🧪 Drill Report",
             "",
-            f"Scenario: team",
+            f"Scenario: {scenario.id}",
+            f"Title: {scenario.title}",
             f"Score: {max(score, 0)}/100",
             f"Workspace: {workspace}",
             "",
-            *checks,
+            "Checks:",
+            *[f"- {item}" for item in checks],
+            "",
+            "Team Contributions:",
+            *[f"- {line}" for line in contributions],
         ]
 
-        task = orchestrator.task_tracker.latest_active(0)
-        if task is not None:
-            orchestrator.artifact_store.append(ArtifactRecord(
-                task_id=task.id,
-                run_id=orchestrator._task_run_ids.get((0, task.id), ""),
-                type="drill_report",
-                source="drill",
-                summary=f"score={max(score, 0)}",
-                content="\n".join(report_lines),
-            ))
-
         return DrillResult(
-            scenario="team",
+            scenario=scenario.id,
             workspace_dir=workspace,
             score=max(score, 0),
             checks=checks,
             report_text="\n".join(report_lines),
             transcript=transcript,
+            stage_results=stage_results,
         )
+
+    def _build_contributions(self, stage_results: list[DrillStageResult]) -> list[str]:
+        lines = []
+        for result in stage_results:
+            summary = result.summary.replace("\n", " ")[:180]
+            state = "ok" if result.success else "needs_attention"
+            lines.append(f"{result.owner} [{result.name}/{state}] {summary}")
+        return lines
+
+    def _last_agent_message(self, orchestrator: Orchestrator, agent_name: str) -> str:
+        history = orchestrator._histories.get(0, [])
+        for item in reversed(history):
+            if item.get("agent") == agent_name:
+                return item.get("content", "")
+        return ""
+
+    def _stage_success(self, stage_name: str, text: str) -> bool:
+        lowered = text.lower()
+        if stage_name == "kickoff":
+            return "[p0]" in lowered or "验收" in text or "负责人" in text
+        if stage_name == "design":
+            return any(token in text for token in ("约束", "风险", "审查", "设计"))
+        if stage_name == "implementation":
+            return any(token in text for token in ("Files:", "Validation:", "Code Review 请求", "阻塞"))
+        if stage_name == "review":
+            return any(token in text for token in ("LGTM", "打回", "问题", "需改进"))
+        if stage_name == "quality_gate":
+            return any(token in text for token in ("Go", "No-Go", "NO-GO", "风险", "覆盖", "阻断", "验证"))
+        if stage_name == "acceptance":
+            return any(token in text for token in ("验收", "通过", "不通过", "风险"))
+        if stage_name == "release":
+            return any(token in text for token in ("发布", "回滚", "验证", "release"))
+        if stage_name == "retrospective":
+            return any(token in text for token in ("PM", "Dev", "Architect", "团队"))
+        return False

--- a/nexuscrew/memory/crew_memory.py
+++ b/nexuscrew/memory/crew_memory.py
@@ -1,43 +1,211 @@
-"""Shared crew memory — reads/writes crew_memory.md."""
+"""Shared crew memory — SQLite primary store with Markdown summary mirror."""
 from datetime import datetime
 from pathlib import Path
+import re
+import sqlite3
 
 
 class CrewMemory:
+    MAX_FILE_BYTES = 2_000_000
+    TAIL_READ_BYTES = 512_000
+    COMPACT_KEEP_LINES = 4000
+    SUMMARY_NOTE_LIMIT = 80
+
     def __init__(self, path: Path):
         self.path = path
+        self.db_path = path.with_suffix(".db")
+        had_file = path.exists()
+        self._init_db()
         if not path.exists():
-            path.write_text(
-                "# NexusCrew 共享记忆\n\n"
-                "> 所有 Agent 共同读写。Agent 回复末尾加【MEMORY】标记自动追加。\n"
-                "> 人类可直接编辑此文件向团队广播信息。\n\n"
-                "## 项目基础信息\n\n(由 /crew 命令自动填充)\n",
-                encoding="utf-8",
-            )
+            path.write_text(self._initial_text(), encoding="utf-8")
+        self._migrate_sections_from_file_if_needed()
+        self._compact_if_needed()
+        if (not had_file) or self._has_db_content():
+            self._render_summary_file()
 
     def read(self, tail_lines: int = 120) -> str:
         """Return last N lines to limit token injection."""
-        lines = self.path.read_text(encoding="utf-8").splitlines()
+        if not self._has_db_content():
+            return "\n".join(self._read_tail_lines(tail_lines))
+        lines = self._render_lines()
         return "\n".join(lines[-tail_lines:])
 
     def append(self, agent_name: str, note: str) -> None:
         ts = datetime.now().strftime("%Y-%m-%d %H:%M")
-        block = f"\n---\n**[{ts}] {agent_name}**\n{note.strip()}\n"
-        with self.path.open("a", encoding="utf-8") as f:
-            f.write(block)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO memory_notes (actor, content, created_at)
+                VALUES (?, ?, ?)
+                """,
+                (agent_name, note.strip(), ts),
+            )
+        self._render_summary_file()
 
     def overwrite_section(self, header: str, content: str) -> None:
         """Replace or insert a named section (used by ProjectScanner)."""
-        text = self.path.read_text(encoding="utf-8")
-        marker = f"## {header}"
-        block = f"{marker}\n\n{content.strip()}\n"
-        if marker in text:
-            # Replace existing section up to the next ##
-            import re
-            text = re.sub(
-                rf"## {re.escape(header)}.*?(?=\n## |\Z)",
-                block, text, flags=re.DOTALL,
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO memory_sections (header, content, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(header) DO UPDATE SET
+                    content = excluded.content,
+                    updated_at = excluded.updated_at
+                """,
+                (header, content.strip(), datetime.now().isoformat()),
             )
-        else:
-            text += f"\n{block}"
-        self.path.write_text(text, encoding="utf-8")
+        self._render_summary_file()
+
+    def _initial_text(self) -> str:
+        return (
+            "# NexusCrew 共享记忆\n\n"
+            "> 所有 Agent 共同读写。Agent 回复末尾加【MEMORY】标记自动追加。\n"
+            "> 人类可直接编辑此文件向团队广播信息。\n\n"
+            "## 项目基础信息\n\n(由 /crew 命令自动填充)\n"
+        )
+
+    def _connect(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self):
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS memory_sections (
+                    header TEXT PRIMARY KEY,
+                    content TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS memory_notes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    actor TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+                """
+            )
+
+    def _has_db_content(self) -> bool:
+        with self._connect() as conn:
+            sections = conn.execute("SELECT COUNT(*) AS n FROM memory_sections").fetchone()["n"]
+            notes = conn.execute("SELECT COUNT(*) AS n FROM memory_notes").fetchone()["n"]
+        return (sections + notes) > 0
+
+    def _migrate_sections_from_file_if_needed(self):
+        if not self.path.exists():
+            return
+        with self._connect() as conn:
+            count = conn.execute("SELECT COUNT(*) AS n FROM memory_sections").fetchone()["n"]
+            if count > 0:
+                return
+        text = self.path.read_text(encoding="utf-8", errors="replace")
+        matches = list(re.finditer(r"^## (.+)$", text, flags=re.MULTILINE))
+        if not matches:
+            return
+        with self._connect() as conn:
+            for idx, match in enumerate(matches):
+                header = match.group(1).strip()
+                start = match.end()
+                end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+                content = text[start:end].strip()
+                if not content:
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO memory_sections (header, content, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(header) DO NOTHING
+                    """,
+                    (header, content, datetime.now().isoformat()),
+                )
+
+    def _compact_if_needed(self) -> None:
+        try:
+            size = self.path.stat().st_size
+        except FileNotFoundError:
+            self.path.write_text(self._initial_text(), encoding="utf-8")
+            return
+        if size <= self.MAX_FILE_BYTES:
+            return
+        tail_lines = self._read_tail_lines(self.COMPACT_KEEP_LINES)
+        tail_text = "\n".join(line for line in tail_lines if line.strip()).strip()
+        compacted = self._initial_text()
+        if tail_text:
+            compacted += "\n## 历史摘要（自动压缩）\n\n" + tail_text + "\n"
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO memory_sections (header, content, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(header) DO UPDATE SET
+                        content = excluded.content,
+                        updated_at = excluded.updated_at
+                    """,
+                    ("历史摘要（自动压缩）", tail_text, datetime.now().isoformat()),
+                )
+        self.path.write_text(compacted, encoding="utf-8")
+        if self._has_db_content():
+            self._render_summary_file()
+
+    def _read_tail_lines(self, tail_lines: int) -> list[str]:
+        if tail_lines <= 0:
+            return []
+        with self.path.open("rb") as f:
+            f.seek(0, 2)
+            size = f.tell()
+            if size <= 0:
+                return []
+            block = b""
+            cursor = size
+            while cursor > 0 and block.count(b"\n") <= tail_lines + 1:
+                read_size = min(self.TAIL_READ_BYTES, cursor)
+                cursor -= read_size
+                f.seek(cursor)
+                block = f.read(read_size) + block
+                if len(block) > self.TAIL_READ_BYTES * 4:
+                    break
+        text = block.decode("utf-8", errors="replace")
+        lines = text.splitlines()
+        return lines[-tail_lines:]
+
+    def _render_lines(self) -> list[str]:
+        lines = [
+            "# NexusCrew 共享记忆",
+            "",
+            "> 运行时记忆主存储已迁移到 SQLite；本文件仅保留摘要镜像。",
+            "",
+        ]
+        with self._connect() as conn:
+            sections = conn.execute(
+                "SELECT header, content FROM memory_sections ORDER BY updated_at, header"
+            ).fetchall()
+            notes = conn.execute(
+                """
+                SELECT actor, content, created_at
+                FROM memory_notes
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (self.SUMMARY_NOTE_LIMIT,),
+            ).fetchall()
+        if not sections:
+            lines.extend(["## 项目基础信息", "", "(由 /crew 命令自动填充)", ""])
+        for row in sections:
+            lines.extend([f"## {row['header']}", "", row["content"], ""])
+        if notes:
+            lines.extend(["## 最近记忆", ""])
+            for row in reversed(notes):
+                lines.extend([
+                    f"---",
+                    f"**[{row['created_at']}] {row['actor']}**",
+                    row["content"],
+                    "",
+                ])
+        return lines
+
+    def _render_summary_file(self):
+        self.path.write_text("\n".join(self._render_lines()).rstrip() + "\n", encoding="utf-8")

--- a/nexuscrew/memory/store.py
+++ b/nexuscrew/memory/store.py
@@ -1,6 +1,7 @@
-"""Scoped memory storage."""
+"""SQLite-backed scoped memory storage."""
 import json
-from dataclasses import asdict, dataclass, field
+import sqlite3
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -15,31 +16,119 @@ class MemoryEntry:
 
 
 class ScopedMemoryStore:
-    """Append-only scoped memory store."""
+    """SQLite-backed scoped memory store with legacy JSONL import."""
 
     def __init__(self, path: Path):
-        self.path = path
-        if not self.path.exists():
-            self.path.write_text("", encoding="utf-8")
+        self.legacy_path = path if path.suffix != ".db" else None
+        self.path = path if path.suffix == ".db" else path.with_suffix(".db")
+        self._init_db()
+        self._migrate_legacy_if_needed()
 
-    def append(self, scope: str, actor: str, content: str, importance: int = 1):
-        entry = MemoryEntry(scope=scope, actor=actor, content=content, importance=importance)
-        with self.path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(asdict(entry), ensure_ascii=False) + "\n")
+    def _connect(self):
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self):
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memory_entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    scope TEXT NOT NULL,
+                    actor TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    importance INTEGER NOT NULL,
+                    ts TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memory_scope_ts ON memory_entries(scope, ts)"
+            )
+
+    def _migrate_legacy_if_needed(self):
+        if self.legacy_path is None or not self.legacy_path.exists():
+            return
+        with self._connect() as conn:
+            row = conn.execute("SELECT COUNT(*) AS n FROM memory_entries").fetchone()
+            if row["n"] > 0:
+                return
+        imported = 0
+        with self.legacy_path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                    entry = MemoryEntry(**record)
+                except Exception:
+                    continue
+                self.append(
+                    entry.scope,
+                    entry.actor,
+                    entry.content,
+                    importance=entry.importance,
+                    ts=entry.ts,
+                )
+                imported += 1
+        if imported == 0:
+            return
+
+    def append(
+        self,
+        scope: str,
+        actor: str,
+        content: str,
+        importance: int = 1,
+        ts: str | None = None,
+    ):
+        entry = MemoryEntry(
+            scope=scope,
+            actor=actor,
+            content=content,
+            importance=importance,
+            ts=ts or datetime.now().isoformat(),
+        )
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO memory_entries (scope, actor, content, importance, ts)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (entry.scope, entry.actor, entry.content, entry.importance, entry.ts),
+            )
 
     def read(self, scope: str, last_n: int = 10) -> list[MemoryEntry]:
-        entries = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            if not line.strip():
-                continue
-            record = json.loads(line)
-            if record["scope"] == scope:
-                entries.append(MemoryEntry(**record))
-        return entries[-last_n:]
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT scope, actor, content, importance, ts
+                FROM memory_entries
+                WHERE scope = ?
+                ORDER BY ts DESC, id DESC
+                LIMIT ?
+                """,
+                (scope, last_n),
+            ).fetchall()
+        entries = [MemoryEntry(**dict(row)) for row in reversed(rows)]
+        return entries
 
     def read_many(self, scopes: list[str], last_n: int = 10) -> list[MemoryEntry]:
-        entries: list[MemoryEntry] = []
-        for scope in scopes:
-            entries.extend(self.read(scope, last_n=last_n))
+        if not scopes:
+            return []
+        placeholders = ", ".join("?" for _ in scopes)
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT scope, actor, content, importance, ts
+                FROM memory_entries
+                WHERE scope IN ({placeholders})
+                ORDER BY importance DESC, ts DESC, id DESC
+                LIMIT ?
+                """,
+                (*scopes, max(last_n * max(len(scopes), 1), last_n)),
+            ).fetchall()
+        entries = [MemoryEntry(**dict(row)) for row in rows]
         entries.sort(key=lambda item: (item.importance, item.ts))
         return entries[-last_n:]

--- a/nexuscrew/orchestrator.py
+++ b/nexuscrew/orchestrator.py
@@ -522,6 +522,12 @@ class Orchestrator:
                 "lgtm", "缺陷", "打回",
             )
             return any(keyword in lowered for keyword in keywords)
+        if agent.role == "qa":
+            keywords = (
+                "测试", "验收", "质量", "回归", "发布", "smoke", "go", "no-go",
+                "风险", "验证", "覆盖", "用例", "检查",
+            )
+            return any(keyword in lowered for keyword in keywords)
         return False
 
     def _is_low_signal_reply(self, agent, reply: str, artifacts) -> bool:
@@ -556,6 +562,25 @@ class Orchestrator:
                 return True
             substantive_markers = ("LGTM", "打回", "缺陷", "风险", "需改进", "需重构", "结论")
             return not any(marker in text for marker in substantive_markers)
+        if agent.role == "qa":
+            if getattr(artifacts, "shell_output", ""):
+                return False
+            if "@" in text and any(fragment in text for fragment in ("Go", "No-Go", "NO-GO", "阻断", "修复", "回归")):
+                return False
+            progress_fragments = (
+                "在测", "测试中", "稍后给结论", "稍后同步", "先看一下", "先跑一下",
+                "正在验证", "结果随后", "回头给结论",
+            )
+            if any(fragment in text for fragment in progress_fragments):
+                return True
+            low_signal_replies = (
+                "ok", "收到", "在", "收到，先测一下", "收到，稍后给结论",
+                "收到，先验证一下", "收到，测试中。",
+            )
+            if normalized in low_signal_replies or len(text) < 120:
+                return True
+            substantive_markers = ("Go", "No-Go", "NO-GO", "风险", "覆盖", "验证", "阻断", "结论")
+            return not any(marker in text for marker in substantive_markers)
         return False
 
     def _build_substantive_retry_prompt(self, agent, message: str, reply: str) -> str:
@@ -572,6 +597,13 @@ class Orchestrator:
                 f"你刚才的回复是：{reply}\n\n"
                 "这不是有效评审。请直接给出评审结论："
                 "LGTM，或列出具体缺陷并 @具体负责人。不要只确认收到。"
+            )
+        if agent.role == "qa":
+            return (
+                f"{message}\n\n"
+                f"你刚才的回复是：{reply}\n\n"
+                "这不是有效测试结论。请直接给出 Go / No-Go、覆盖项、风险项，"
+                "或者直接执行最小必要的验证命令并汇报结果。不要只汇报状态。"
             )
         return message
 
@@ -638,6 +670,11 @@ class Orchestrator:
             if pm:
                 return f"⚠️ @{agent.name} 在任务 {task_id} 上评审超时。@{pm.name} 请调整计划或改派。"
             return f"⚠️ @{agent.name} 在任务 {task_id} 上评审超时，请人工介入。"
+        if agent.role == "qa":
+            pm = self.router.default_agent()
+            if pm:
+                return f"⚠️ @{agent.name} 在任务 {task_id} 上测试验证超时。@{pm.name} 请调整计划或改派。"
+            return f"⚠️ @{agent.name} 在任务 {task_id} 上测试验证超时，请人工介入。"
         if agent.role == "pm":
             return f"⚠️ @{agent.name} 在任务 {task_id} 上编排超时，请人工介入。"
         return f"⚠️ @{agent.name} 在任务 {task_id} 上响应超时，请人工介入。"
@@ -654,6 +691,11 @@ class Orchestrator:
             if pm:
                 return f"⚠️ @{agent.name} 未给出有效评审结论。@{pm.name} 请调整计划或改派（task {task_id}）。"
             return f"⚠️ @{agent.name} 未给出有效评审结论，请人工介入（task {task_id}）。"
+        if agent.role == "qa":
+            pm = self.router.default_agent()
+            if pm:
+                return f"⚠️ @{agent.name} 未给出有效测试结论。@{pm.name} 请调整计划或改派（task {task_id}）。"
+            return f"⚠️ @{agent.name} 未给出有效测试结论，请人工介入（task {task_id}）。"
         if agent.role == "pm":
             return f"⚠️ @{agent.name} 未给出有效编排结果，请人工介入（task {task_id}）。"
         return f"⚠️ @{agent.name} 未给出有效结果，请人工介入（task {task_id}）。"

--- a/nexuscrew/router.py
+++ b/nexuscrew/router.py
@@ -13,6 +13,9 @@ ROLE_ALIASES: dict[str, str] = {
     "architect": "architect",
     "arch": "architect",
     "hr": "hr",  # Task 1.2 完成: 支持 HR 角色别名路由。
+    "qa": "qa",
+    "test": "qa",
+    "tester": "qa",
 }
 
 _MENTION_RE = re.compile(r"@(\w+)")

--- a/nexuscrew/setup_wizard.py
+++ b/nexuscrew/setup_wizard.py
@@ -55,6 +55,7 @@ def _default_model(role: str) -> str:
         "dev": "codex",
         "architect": "claude",
         "hr": "claude",
+        "qa": "claude",
     }.get(role, "claude")
 
 
@@ -683,9 +684,9 @@ def render_setup_html(message: str = "", launch_ready: bool = False,
             "Dev 2",
             "Architect",
             "HR",
+            "QA",
             "Extra 1",
             "Extra 2",
-            "Extra 3",
         ]
         for idx, label in enumerate(placeholders, start=1):
             rows.append(
@@ -836,7 +837,7 @@ def render_setup_html(message: str = "", launch_ready: bool = False,
               <div class="grid">
                 <div class="field"><label>Project Directory</label><input name="project_dir" value="{val('project_dir')}" placeholder="~/myproject"></div>
                 <div class="field"><label>Project Prefix</label><input name="project_prefix" value="{val('project_prefix', 'nexus')}"></div>
-                <div class="field"><label>Agent Specs</label><textarea name="agent_specs">{html.escape(defaults.get('agent_specs', 'pm:nexus-pm-01(claude)\ndev:nexus-dev-01(codex)\narchitect:nexus-arch-01(claude)\nhr:nexus-hr-01(claude)'))}</textarea></div>
+                <div class="field"><label>Agent Specs</label><textarea name="agent_specs">{html.escape(defaults.get('agent_specs', 'pm:nexus-pm-01(claude)\ndev:nexus-dev-01(codex)\narchitect:nexus-arch-01(claude)\nhr:nexus-hr-01(claude)\nqa:nexus-qa-01(claude)'))}</textarea></div>
                 <div class="field"><label>Max Chain Hops</label><input name="max_chain_hops" value="{val('max_chain_hops', '10')}"></div>
                 <div class="field"><label>Max Dev Retry</label><input name="max_dev_retry" value="{val('max_dev_retry', '5')}"></div>
                 <div class="field"><label>History Window</label><input name="history_window" value="{val('history_window', '20')}"></div>

--- a/nexuscrew/telegram/bot.py
+++ b/nexuscrew/telegram/bot.py
@@ -22,6 +22,7 @@ from ..agents.pm import PMAgent
 from ..agents.dev import DevAgent
 from ..agents.architect import ArchitectAgent
 from ..agents.hr import HRAgent
+from ..agents.qa import QAAgent
 from ..backends.gemini_cli import GeminiCLIBackend
 from ..backends.openai_backend import OpenAIBackend
 from ..backends.anthropic_backend import AnthropicBackend
@@ -50,6 +51,7 @@ MODEL_DEFAULTS = {
     "dev": "codex",
     "architect": "claude",
     "hr": "claude",
+    "qa": "claude",
 }
 
 
@@ -89,6 +91,8 @@ def _make_agent(role: str, name: str, model: str, executor: ShellExecutor,
         return ArchitectAgent(name, backend, extra)
     if role == "hr":
         return HRAgent(name, backend, extra, model_label=model)
+    if role == "qa":
+        return QAAgent(name, backend, executor, extra, model_label=model)
     raise ValueError(f"Unknown role: {role}")
 
 

--- a/secrets.example.py
+++ b/secrets.example.py
@@ -12,6 +12,8 @@ AGENT_BOT_TOKENS: dict[str, str] = {
     # "nexus-dev-01":  "7xxx:BBB...",
     # "nexus-dev-02":  "7xxx:CCC...",
     # "nexus-arch-01": "7xxx:DDD...",
+    # "nexus-hr-01":   "7xxx:EEE...",
+    # "nexus-qa-01":   "7xxx:FFF...",
 }
 # Bot @username → Agent 名字映射
 BOT_USERNAME_MAP: dict[str, str] = {
@@ -19,6 +21,8 @@ BOT_USERNAME_MAP: dict[str, str] = {
     # "nexus_dev_01_bot":  "nexus-dev-01",
     # "nexus_dev_02_bot":  "nexus-dev-02",
     # "nexus_arch_01_bot": "nexus-arch-01",
+    # "nexus_hr_01_bot":   "nexus-hr-01",
+    # "nexus_qa_01_bot":   "nexus-qa-01",
 }
 
 # ── OpenAI / Codex  (Dev Agent: nexus-dev-XX) ──────────────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,10 +15,25 @@ def test_load_crew_config_parses_example_yaml():
     assert config.project_dir == Path("~/myproject").expanduser()
     assert config.project_prefix == "nexus"
     assert [agent.role for agent in config.agents] == [
-        "pm", "dev", "dev", "architect", "hr",
+        "pm", "dev", "dev", "architect", "hr", "qa",
     ]
     assert config.orchestrator.max_chain_hops == 10
     assert config.hr.anomaly_triggers["dev_retry_threshold"] == 3
+
+
+def test_make_agent_supports_qa_role(monkeypatch, tmp_path: Path):
+    from nexuscrew.agents.qa import QAAgent
+    from nexuscrew.executor.shell import ShellExecutor
+
+    monkeypatch.setattr(bot_module.cfg, "ANTHROPIC_API_KEY", "sk-ant-test", raising=False)
+    monkeypatch.setattr(bot_module.cfg, "ANTHROPIC_BASE_URL", "https://anth.example.com/", raising=False)
+    monkeypatch.setattr(bot_module.cfg, "ANTHROPIC_MODEL", "claude-opus-4-6", raising=False)
+    monkeypatch.setattr(bot_module.cfg, "ANTHROPIC_MODEL_SONNET", "claude-sonnet-4-6", raising=False)
+
+    agent = bot_module._make_agent("qa", "nexus-qa-01", "claude", ShellExecutor(tmp_path))
+
+    assert isinstance(agent, QAAgent)
+    assert agent.role == "qa"
 
 
 def test_load_crew_config_requires_project_dir(tmp_path: Path):

--- a/tests/test_crew_memory.py
+++ b/tests/test_crew_memory.py
@@ -1,0 +1,43 @@
+"""Tests for crew memory tail reads and auto compaction."""
+from pathlib import Path
+
+from nexuscrew.memory.crew_memory import CrewMemory
+
+
+def test_crew_memory_read_returns_tail_without_full_file_load(tmp_path: Path):
+    path = tmp_path / "crew_memory.md"
+    path.write_text("\n".join(f"line {i}" for i in range(200)), encoding="utf-8")
+
+    mem = CrewMemory(path)
+
+    assert mem.read(tail_lines=3) == "line 197\nline 198\nline 199"
+
+
+def test_crew_memory_compacts_large_file_before_overwrite(tmp_path: Path, monkeypatch):
+    path = tmp_path / "crew_memory.md"
+    path.write_text(
+        "# NexusCrew 共享记忆\n\n" + "\n".join(f"memo {i}" for i in range(5000)),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(CrewMemory, "MAX_FILE_BYTES", 512, raising=False)
+    monkeypatch.setattr(CrewMemory, "COMPACT_KEEP_LINES", 20, raising=False)
+    monkeypatch.setattr(CrewMemory, "TAIL_READ_BYTES", 256, raising=False)
+
+    mem = CrewMemory(path)
+    mem.overwrite_section("项目简报", "briefing")
+
+    text = path.read_text(encoding="utf-8")
+    assert "## 项目简报" in text
+    assert "briefing" in text
+    assert "## 历史摘要（自动压缩）" in text
+    assert path.stat().st_size < 4096
+
+
+def test_crew_memory_append_reads_from_sqlite_primary_store(tmp_path: Path):
+    path = tmp_path / "crew_memory.md"
+    mem = CrewMemory(path)
+
+    mem.append("alice", "记住这个约定")
+
+    assert "记住这个约定" in mem.read(tail_lines=20)
+    assert path.with_suffix(".db").exists()

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -2,9 +2,10 @@
 import asyncio
 from pathlib import Path
 from types import SimpleNamespace
+import random
 
 from nexuscrew.config import AgentSpec, CrewConfig
-from nexuscrew.drill import TeamDrillRunner
+from nexuscrew.drill import DrillScenario, DrillStageResult, TeamDrillRunner
 from nexuscrew.task_state import Task, TaskStatus
 from nexuscrew.telegram import bot as bot_module
 from nexuscrew.telegram.bot import NexusCrewBot
@@ -19,15 +20,34 @@ def test_team_drill_runner_builds_minimal_config(tmp_path: Path):
             AgentSpec(role="dev", name="dev-2", model="codex"),
             AgentSpec(role="architect", name="arch-1", model="claude"),
             AgentSpec(role="hr", name="hr-1", model="claude"),
+            AgentSpec(role="qa", name="qa-1", model="claude"),
         ],
     )
 
     runner = TeamDrillRunner(config, lambda spec, executor: None)
     drill_config = runner._build_drill_config(tmp_path / "workspace")
 
-    assert [agent.role for agent in drill_config.agents] == ["pm", "dev", "architect"]
-    assert [agent.name for agent in drill_config.agents] == ["pm-1", "dev-1", "arch-1"]
+    assert [agent.role for agent in drill_config.agents] == ["pm", "dev", "architect", "hr", "qa"]
+    assert [agent.name for agent in drill_config.agents] == ["pm-1", "dev-1", "arch-1", "hr-1", "qa-1"]
     assert drill_config.hr.auto_eval_daily_limit == 0
+
+
+def test_team_drill_runner_chooses_random_scenario(monkeypatch, tmp_path: Path):
+    config = CrewConfig(
+        project_dir=tmp_path,
+        agents=[
+            AgentSpec(role="pm", name="pm-1", model="claude"),
+            AgentSpec(role="dev", name="dev-1", model="codex"),
+            AgentSpec(role="architect", name="arch-1", model="claude"),
+        ],
+    )
+    runner = TeamDrillRunner(config, lambda spec, executor: None)
+    monkeypatch.setattr(random, "SystemRandom", lambda: SimpleNamespace(choice=lambda items: items[0]))
+
+    scenario = runner._choose_scenario("team")
+
+    assert isinstance(scenario, DrillScenario)
+    assert scenario.id == runner.SCENARIOS[0].id
 
 
 def test_team_drill_runner_builds_report(tmp_path: Path):
@@ -42,7 +62,7 @@ def test_team_drill_runner_builds_report(tmp_path: Path):
     runner = TeamDrillRunner(config, lambda spec, executor: None)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    (workspace / "DRILL_NOTE.md").write_text("drill ok\n", encoding="utf-8")
+    (workspace / "DRILL_NOTE.md").write_text("drill ok\nstatus-board-hardening\n", encoding="utf-8")
 
     task = Task(id="T-0001", description="drill", status=TaskStatus.PLANNING)
 
@@ -70,13 +90,37 @@ def test_team_drill_runner_builds_report(tmp_path: Path):
         ("arch-1", "**[arch-1]**\nLGTM"),
     ]
 
-    report = asyncio.run(runner._build_report(orchestrator, config, workspace, transcript))
+    scenario = DrillScenario(
+        id="status-board-hardening",
+        title="Harden stale-task status board behavior",
+        summary="summary",
+        acceptance=["a", "b"],
+        release_goal="release",
+    )
+    stage_results = [
+        DrillStageResult("kickoff", "pm-1", "负责人和验收标准已给出", True),
+        DrillStageResult("design", "arch-1", "设计约束明确", True),
+        DrillStageResult("implementation", "dev-1", "Files: DRILL_NOTE.md / Validation: 1 passed", True),
+        DrillStageResult("review", "arch-1", "LGTM", True),
+        DrillStageResult("quality_gate", "qa-1", "结论: Go / 验证: smoke passed", True),
+        DrillStageResult("acceptance", "pm-1", "验收通过", True),
+        DrillStageResult("release", "pm-1", "发布说明已给出", True),
+    ]
+
+    report = asyncio.run(runner._build_report(
+        orchestrator,
+        config,
+        workspace,
+        scenario,
+        transcript,
+        stage_results,
+    ))
 
     assert report.score == 100
-    assert "PM: pass" in report.report_text
-    assert "Dev: pass" in report.report_text
-    assert "Architect: pass" in report.report_text
-    assert orchestrator.artifact_store.items
+    assert "Kickoff: pass" in report.report_text
+    assert "Review: pass" in report.report_text
+    assert "Quality Gate: pass" in report.report_text
+    assert "Team Contributions:" in report.report_text
 
 
 def test_cmd_drill_submits_background_job(monkeypatch):

--- a/tests/test_next_stack.py
+++ b/tests/test_next_stack.py
@@ -101,6 +101,21 @@ def test_scoped_memory_retriever(tmp_path: Path):
     assert "对 bob 的提醒" in retrieved
 
 
+def test_scoped_memory_store_imports_legacy_jsonl(tmp_path: Path):
+    legacy = tmp_path / "scoped_memory.jsonl"
+    legacy.write_text(
+        '{"scope":"shared","actor":"human","content":"旧上下文","importance":2,"ts":"2026-03-28T10:00:00"}\n',
+        encoding="utf-8",
+    )
+
+    store = ScopedMemoryStore(legacy)
+
+    entries = store.read("shared", last_n=5)
+
+    assert [item.content for item in entries] == ["旧上下文"]
+    assert legacy.with_suffix(".db").exists()
+
+
 def test_trace_store_and_stuck_detector(tmp_path: Path):
     store = EventStore(tmp_path / "events.jsonl")
     store.append(RunEvent(run_id="run-1", chat_id=1, task_id="T-0001", type="shell_finished", actor="bob", payload={"output": "failed"}))

--- a/tests/test_orchestrator_substance.py
+++ b/tests/test_orchestrator_substance.py
@@ -116,6 +116,39 @@ def test_orchestrator_escalates_when_architect_stays_low_signal_twice(tmp_path: 
     assert any("@alice" in text for text in sent)
 
 
+def test_orchestrator_escalates_when_qa_stays_low_signal_twice(tmp_path: Path):
+    registry = AgentRegistry()
+    registry.register(SequencedAgent(
+        "alice",
+        "pm",
+        ["收到，我来调整计划。"],
+    ))
+    registry.register(SequencedAgent(
+        "qa-1",
+        "qa",
+        [
+            "在测，稍后给结论。",
+            "先跑一下，结果随后。",
+        ],
+    ))
+    orchestrator = Orchestrator(
+        registry,
+        Router(registry),
+        CrewMemory(tmp_path / "crew_memory.md"),
+        ShellExecutor(tmp_path),
+    )
+
+    sent: list[str] = []
+
+    async def send(text: str, agent_name: str | None = None):
+        sent.append(text)
+
+    asyncio.run(orchestrator.run_chain("@qa-1 请做回归测试并给 Go / No-Go", 1, send))
+
+    assert any("未给出有效测试结论" in text for text in sent)
+    assert any("@alice" in text for text in sent)
+
+
 def test_orchestrator_watchdog_reports_and_times_out(tmp_path: Path):
     class SlowAgent(BaseAgent):
         def __init__(self, name: str, role: str):

--- a/tests/test_qa_agent.py
+++ b/tests/test_qa_agent.py
@@ -1,0 +1,73 @@
+"""Tests for QA agent shell execution and memory behavior."""
+import asyncio
+from pathlib import Path
+
+from nexuscrew.agents.qa import QAAgent
+from nexuscrew.agents import qa as qa_module
+from nexuscrew.executor.shell import ShellExecutor
+
+
+class FakeGeminiBackend:
+    def __init__(self, reply: str):
+        self.reply = reply
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self.reply
+
+
+class FakeAnthropicBackend:
+    def __init__(self, reply: str):
+        self.reply = reply
+        self.calls: list[tuple[str, list[dict]]] = []
+
+    def complete(self, system: str, messages: list[dict], use_thinking: bool = False,
+                 light_mode: bool = False) -> str:
+        self.calls.append((system, messages))
+        return self.reply
+
+
+async def _direct_to_thread(func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+def test_qa_agent_extracts_memory_note_and_runs_shell(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(qa_module.asyncio, "to_thread", _direct_to_thread)
+    executor = ShellExecutor(tmp_path)
+
+    async def fake_run_blocks(reply: str) -> str:
+        assert "```bash" in reply
+        return "pytest passed"
+
+    monkeypatch.setattr(executor, "run_blocks", fake_run_blocks)
+    agent = QAAgent(
+        "qa-1",
+        FakeAnthropicBackend("```bash\npytest -q\n```\n结论: Go【MEMORY】保留质量闸门"),
+        executor,
+        model_label="claude",
+    )
+
+    reply, artifacts = asyncio.run(agent.handle("做回归测试", [], "memory"))
+
+    assert reply == "```bash\npytest -q\n```\n结论: Go"
+    assert artifacts.shell_output == "pytest passed"
+    assert artifacts.memory_note == "保留质量闸门"
+
+
+def test_qa_agent_supports_gemini_backend(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(qa_module.asyncio, "to_thread", _direct_to_thread)
+    executor = ShellExecutor(tmp_path)
+
+    async def fake_run_blocks(reply: str) -> str:
+        return ""
+
+    monkeypatch.setattr(executor, "run_blocks", fake_run_blocks)
+    backend = FakeGeminiBackend("结论: No-Go")
+    agent = QAAgent("qa-1", backend, executor, model_label="gemini")
+
+    reply, artifacts = asyncio.run(agent.handle("做冒烟测试", [], "memory"))
+
+    assert reply == "结论: No-Go"
+    assert artifacts.memory_note == ""
+    assert "做冒烟测试" in backend.prompts[0]

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -38,6 +38,10 @@ class TestDetectFirst:
         router = _setup(_agent("nexus-hr-01", "hr"))
         assert router.detect_first("@hr 出绩效报告").name == "nexus-hr-01"
 
+    def test_role_alias_qa(self):
+        router = _setup(_agent("nexus-qa-01", "qa"))
+        assert router.detect_first("@qa 做回归测试").name == "nexus-qa-01"
+
     def test_no_mention_returns_none(self):
         router = _setup(_agent("alice", "pm"))
         assert router.detect_first("没有 mention 的消息") is None
@@ -66,6 +70,16 @@ class TestDetectFirst:
         )
         router = _setup(_agent("nexus-dev-02", "dev"), _agent("alice", "pm"))
         assert router.detect_first("@nexus_dev_02_bot 你呢").name == "nexus-dev-02"
+
+    def test_qa_bot_username_maps_to_agent_name(self, monkeypatch):
+        monkeypatch.setattr(
+            router_module.cfg,
+            "BOT_USERNAME_MAP",
+            {"nexus_qa_01_bot": "nexus-qa-01"},
+            raising=False,
+        )
+        router = _setup(_agent("nexus-qa-01", "qa"), _agent("alice", "pm"))
+        assert router.detect_first("@nexus_qa_01_bot 做一轮验收").name == "nexus-qa-01"
 
 
 class TestDetectAll:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -35,7 +35,7 @@ def test_setup_wizard_builds_secrets_and_crew(tmp_path: Path):
         "anthropic_api_key": "sk-ant-test",
         "project_dir": "/tmp/project",
         "project_prefix": "nexus",
-        "agent_specs": "pm:nexus-pm-01(claude)\ndev:nexus-dev-01(codex)\narchitect:nexus-arch-01(claude)\nhr:nexus-hr-01(claude)",
+        "agent_specs": "pm:nexus-pm-01(claude)\ndev:nexus-dev-01(codex)\narchitect:nexus-arch-01(claude)\nhr:nexus-hr-01(claude)\nqa:nexus-qa-01(claude)",
     }
 
     secrets_text = build_secrets_py(form)
@@ -120,6 +120,16 @@ def test_validate_setup_allows_blank_gemini_when_unused(tmp_path: Path):
     )
 
     assert not any("GEMINI_CLI_CMD" in issue for issue in issues)
+
+
+def test_build_crew_local_yaml_keeps_qa_as_claude():
+    crew_yaml = build_crew_local_yaml({
+        "project_dir": "/tmp/project",
+        "agent_specs": "qa:nexus-qa-01",
+    })
+
+    assert "role: qa" in crew_yaml
+    assert "model: claude" in crew_yaml
 
 
 def test_launch_nexuscrew_uses_local_yaml_when_present(tmp_path: Path, monkeypatch):
@@ -234,6 +244,7 @@ def test_render_setup_html_includes_stepper_and_checks():
     assert "连接测试结果" in html
     assert "123:abc" in html
     assert "运行状态" in html
+    assert "qa:nexus-qa-01(claude)" in html
 
 
 def test_render_success_and_console_html(tmp_path: Path):


### PR DESCRIPTION
## Overview

This PR adds a dedicated QA role to NexusCrew and migrates runtime memory persistence away from oversized Markdown / JSONL files toward SQLite-backed storage.

The goal of this release is twofold:
- introduce a real testing specialist into the multi-bot team workflow
- eliminate a startup and reliability failure mode caused by unbounded memory files

## What Changed

### 1. New QA Role

A new `qa` role is now supported across the runtime:
- router aliases: `@qa`, `@test`, `@tester`
- dedicated bot mapping support for `nexus-qa-01`
- Claude-backed QA agent with a release-gate / testing-specialist prompt
- setup/onboarding defaults updated to include QA in agent specs
- local crew wiring updated so QA participates in real team orchestration

QA is designed as a real quality gate, not a passive observer:
- gives `Go / No-Go` judgments
- focuses on regression, edge cases, release risk, and verification coverage
- escalates if it responds with low-signal status chatter instead of real test conclusions

### 2. Runtime Memory Migration to SQLite

Previously, `crew_memory.md` could grow without bound and was also used as an active runtime write target.

That created a real failure mode:
- startup preloading rewrote sections inside `crew_memory.md`
- once the file became very large, startup could hang before Telegram polling actually began
- this resulted in messages piling up in Telegram while the process looked half-started

This PR changes the model:
- runtime memory primary store is now SQLite-backed
- scoped memory is also SQLite-backed
- `crew_memory.md` remains as a small human-readable summary mirror only
- legacy `scoped_memory.jsonl` can be imported into the new SQLite store
- automatic compaction protects against oversized memory files

## Operator Impact

After this PR:
- NexusCrew startup is no longer blocked by huge memory files
- Telegram polling can start reliably even after long runtime history
- QA can be addressed directly in group workflows
- `/drill` can now include a QA quality-gate stage when QA exists in the crew
- memory remains readable to humans, but durable storage no longer depends on large append-only Markdown / JSONL files

## Key Files

- `nexuscrew/agents/qa.py`
- `nexuscrew/router.py`
- `nexuscrew/telegram/bot.py`
- `nexuscrew/orchestrator.py`
- `nexuscrew/memory/crew_memory.py`
- `nexuscrew/memory/store.py`
- `nexuscrew/drill.py`
- `crew.example.yaml`
- `secrets.example.py`

## Validation

Validated locally and during push:
- `python3 -m pytest tests/test_crew_memory.py tests/test_next_stack.py tests/test_pressure.py tests/test_hr_evaluation.py tests/test_config.py tests/test_router.py tests/test_setup_wizard.py -q`
- Git pre-push verification ran full suite:
  - `pytest -q`
  - Result: `161 passed`

## Notes

- `crew_memory.md` is still kept as a local-readable artifact, but it is no longer the runtime system of record.
- This PR intentionally keeps the user-facing memory summary while moving the operational storage path to SQLite.
- QA is now a first-class role in routing, onboarding, drill flow, and runtime enforcement.
